### PR TITLE
Update couple_set.cc to fix binding

### DIFF
--- a/src/sim/couple_set.cc
+++ b/src/sim/couple_set.cc
@@ -1020,7 +1020,7 @@ void CoupleSet::uniAttach(FiberSet const& fibers)
         
         if ( cnt > 0 )
         {
-            const real alpha = 2 * P->spaceVolume() / cnt;
+            const real alpha = P->spaceVolume() / cnt;
             
             if ( P->fast_diffusion == 2 )
             {


### PR DESCRIPTION
Got rid of a "times 2" so that each hand retains its prescribed binding rate within the couple, and this binding rate is no longer halved.